### PR TITLE
+events to permset

### DIFF
--- a/force-app/main/default/permissionsets/TransactionSecurity.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/TransactionSecurity.permissionset-meta.xml
@@ -42,4 +42,12 @@
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>TransactionSecurity</label>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>ViewDataLeakageEvents</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>ViewEventLogFiles</name>
+    </userPermissions>
 </PermissionSet>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "version": "1.0.0",
   "description": "Salesforce App",
   "scripts": {
+    "build": "yarn destroy; ./orgInit.sh",
+    "destroy": "sfdx shane:org:delete",
     "lint": "npm run lint:lwc",
     "lint:lwc": "eslint force-app/main/default/lwc",
     "test": "npm run test:unit",


### PR DESCRIPTION
this isn't germane to your demo, but it does let someone optionally demo streaming events where you can see the event (like `shane:events:stream -e LightningUriEventStream`) by adding that access to the permset.